### PR TITLE
add amazon-ebs

### DIFF
--- a/lib/packerman.rb
+++ b/lib/packerman.rb
@@ -9,6 +9,7 @@ require 'packerman/client'
 require 'packerman/evaluator'
 require 'packerman/dsl'
 require 'packerman/dsl/node'
+require 'packerman/dsl/hash_object'
 require 'packerman/dsl/builders'
 require 'packerman/dsl/builders/amazon_ebs'
 

--- a/lib/packerman/dsl/builders/amazon_ebs.rb
+++ b/lib/packerman/dsl/builders/amazon_ebs.rb
@@ -17,5 +17,55 @@ class Packerman::Dsl::Builders::AmazonEbs < Packerman::Dsl::Builders
         :ssh_username,
       ]
     end
+
+    def optional_keys
+      [
+        :ami_block_device_mappings,
+        :ami_description,
+        :ami_groups,
+        :ami_product_codes,
+        :ami_regions,
+        :ami_users,
+        :associate_public_ip_address,
+        :availability_zone,
+        :enhanced_networking,
+        :force_deregister,
+        :iam_instance_profile,
+        :launch_block_device_mappings,
+        :run_tags,
+        :security_group_id,
+        :security_group_ids,
+        :spot_price,
+        :spot_price_auto_product,
+        :ssh_keypair_name,
+        :ssh_private_ip,
+        :subnet_id,
+        :tags,
+        :temporary_key_pair_name,
+        :token,
+        :user_data,
+        :user_data_file,
+        :vpc_id,
+        :windows_password_timeout,
+      ]
+    end
+
+    class AmiBlockDeviceMapping < Packerman::Dsl::HashObject
+      class << self
+        def optional_keys
+          [
+            :delete_on_termination,
+            :device_name,
+            :encrypted,
+            :iops,
+            :no_device,
+            :snapshot_id,
+            :virtual_name,
+            :volume_type,
+            :volume_size
+          ]
+        end
+      end
+    end
   end
 end

--- a/lib/packerman/dsl/hash_object.rb
+++ b/lib/packerman/dsl/hash_object.rb
@@ -1,0 +1,20 @@
+class Packerman::Dsl::HashObject < Packerman::Dsl
+  include Packerman::Dsl::Node
+  class << self
+    def register_to_repo(product)
+      product
+    end
+
+    def to_subclass(_type)
+      self
+    end
+
+    def hash_key
+      require_keys + optional_keys
+    end
+
+    def inherited(klass)
+      Packerman::Dsl.const_set(klass.name.demodulize, klass)
+    end
+  end
+end

--- a/lib/packerman/dsl/node.rb
+++ b/lib/packerman/dsl/node.rb
@@ -15,11 +15,15 @@ module Packerman::Dsl::Node
   end
 
   def to_hash
-    keys = [:type] + self.class.require_keys + self.class.optional_keys
+    keys = self.class.hash_key
     @_hash.slice(*keys)
   end
 
   class_methods do
+    def hash_key
+      [:type] + require_keys + optional_keys
+    end
+
     def require_keys
       []
     end

--- a/lib/packerman/repository.rb
+++ b/lib/packerman/repository.rb
@@ -9,6 +9,7 @@ class Packerman::Repository
     define_method "add_#{attr}" do |hash|
       @_repo[attr] ||= []
       @_repo[attr] << hash
+      hash
     end
   end
 

--- a/spec/lib/evaluator_spec.rb
+++ b/spec/lib/evaluator_spec.rb
@@ -22,6 +22,18 @@ describe Packerman::Evaluator do
           ssh_username  "ec2-user"
         end
 
+        block_device = AmiBlockDeviceMapping.register do
+          delete_on_termination true
+          device_name "devise"
+          encrypted false
+          iops 200_000
+          no_device true
+          snapshot_id "omg"
+          virtual_name "virrrtual"
+          volume_type "type"
+          volume_size 20
+        end
+
         Builders type: :"amazon-ebs" do
           access_key    "access_key"
           ami_name      "whoami2"
@@ -30,6 +42,20 @@ describe Packerman::Evaluator do
           secret_key    "secret_key"
           source_ami    "iam_ubuntu"
           ssh_username  "ubuntu"
+          ami_block_device_mappings [
+            AmiBlockDeviceMapping.register {
+              delete_on_termination true
+              device_name "devise"
+              encrypted false
+              iops 200_000
+              no_device true
+              snapshot_id "omg"
+              virtual_name "virrrtual"
+              volume_type "type"
+              volume_size 20
+            },
+            block_device
+          ]
         end
         EOS
       end
@@ -55,7 +81,31 @@ describe Packerman::Evaluator do
               region: "ap-northeast-1",
               secret_key: "secret_key",
               source_ami: "iam_ubuntu",
-              ssh_username: "ubuntu"
+              ssh_username: "ubuntu",
+              ami_block_device_mappings: [
+                {
+                  delete_on_termination: true,
+                  device_name: "devise",
+                  encrypted: false,
+                  iops: 200_000,
+                  no_device: true,
+                  snapshot_id: "omg",
+                  virtual_name: "virrrtual",
+                  volume_type: "type",
+                  volume_size: 20
+                },
+                {
+                  delete_on_termination: true,
+                  device_name: "devise",
+                  encrypted: false,
+                  iops: 200_000,
+                  no_device: true,
+                  snapshot_id: "omg",
+                  virtual_name: "virrrtual",
+                  volume_type: "type",
+                  volume_size: 20
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
implements of [amazon-ebs builder](https://www.packer.io/docs/builders/amazon-ebs.html#ami_block_device_mappings)

[markdown](https://github.com/mitchellh/packer/blob/135a607fb47e0b2ab4a48c152d583efcd8bde974/website/source/docs/builders/amazon-ebs.html.markdown)

usage:

``` ruby
block_device = AmiBlockDeviceMapping.register do
  delete_on_termination true
  device_name "devise"
  encrypted false
  iops 200_000
  no_device true
  snapshot_id "omg"
  virtual_name "virrrtual"
  volume_type "type"
  volume_size 20
end

Builders type: "amazon-ebs" do
  access_key    "access_key"
  ami_name      "whoami2"
  instance_type "t2.small"
  region        "ap-northeast-1"
  secret_key    "secret_key"    
  source_ami    "iam_ubuntu"          
  ssh_username  "ubuntu"
  ami_block_device_mappings [
    AmiBlockDeviceMapping.register {
      delete_on_termination true
      device_name "devise"
      encrypted false
      iops 200_000
      no_device true
      snapshot_id "omg"
      virtual_name "virrrtual"
      volume_type "type"
      volume_size 20
    },
    block_device
  ]
end
```
