### PR TITLE
add amazon_chroot

### DIFF
--- a/lib/packerman.rb
+++ b/lib/packerman.rb
@@ -13,6 +13,9 @@ require 'packerman/dsl/hash_object'
 require 'packerman/dsl/builders'
 require 'packerman/dsl/builders/amazon_ebs'
 require 'packerman/dsl/builders/amazon_instance'
+require 'packerman/dsl/builders/amazon_chroot'
+
+
 
 module Packerman
 end

--- a/lib/packerman/dsl/builders/amazon_chroot.rb
+++ b/lib/packerman/dsl/builders/amazon_chroot.rb
@@ -1,0 +1,39 @@
+class Packerman::Dsl::Builders::AmazonChroot< Packerman::Dsl::Builders
+  include Packerman::Dsl::Node
+
+  def type
+    "amazon-chroot"
+  end
+
+  class << self
+    def require_keys
+      [
+        :access_key,
+        :ami_name,
+        :secret_key,
+        :source_ami
+      ]
+    end
+
+    def optional_keys
+      [
+        :ami_description,
+        :ami_groups,
+        :ami_product_codes,
+        :ami_regions,
+        :ami_users,
+        :ami_virtualization_type,
+        :chroot_mounts,
+        :command_wrapper,
+        :copy_files,
+        :device_path,
+        :enhanced_networking,
+        :force_deregister,
+        :mount_path,
+        :mount_options,
+        :root_volume_size,
+        :tags
+      ]
+    end
+  end
+end

--- a/spec/lib/evaluator_spec.rb
+++ b/spec/lib/evaluator_spec.rb
@@ -193,6 +193,37 @@ describe Packerman::Evaluator do
 
         it_behaves_like :evaluated
       end
+
+      context "amazon-ebs" do
+        let(:template) do
+          <<-EOS.undent
+          Builders type: :"amazon-chroot" do
+            access_key "access_key"
+            ami_name   "ami_name"
+            secret_key "secret_key"
+            source_ami "amazonlinux"
+            ami_description "yours"
+          end
+          EOS
+        end
+
+        let(:hash) do
+          {
+            builders: [
+              {
+                type: "amazon-chroot",
+                access_key: "access_key",
+                ami_name:   "ami_name",
+                secret_key: "secret_key",
+                source_ami: "amazonlinux",
+                ami_description: "yours"
+              }
+            ]
+          }
+        end
+
+        it_behaves_like :evaluated
+      end
     end
   end
 end


### PR DESCRIPTION
DSL implements for amazon-chroot

``` ruby
Builders type: :"amazon-chroot" do
  access_key "access_key"
  ami_name   "ami_name"
  secret_key "secret_key"
  source_ami "amazonlinux"
  ami_description "yours"
end

```
