### PR TITLE
add chef-solo

### DIFF
--- a/lib/packerman.rb
+++ b/lib/packerman.rb
@@ -17,6 +17,7 @@ require 'packerman/dsl/builders/amazon_chroot'
 require 'packerman/dsl/builders/docker'
 require 'packerman/dsl/provisioners'
 require 'packerman/dsl/provisioners/shell'
+require 'packerman/dsl/provisioners/chef_solo'
 
 module Packerman
 end

--- a/lib/packerman/dsl/provisioners/chef_solo.rb
+++ b/lib/packerman/dsl/provisioners/chef_solo.rb
@@ -1,0 +1,29 @@
+class Packerman::Dsl::Provisioners::ChefSolo < Packerman::Dsl::Builders
+  include Packerman::Dsl::Node
+
+  def type
+    "chef-solo"
+  end
+
+  class << self
+    def optional_keys
+      [
+        :chef_environment,
+        :config_template,
+        :cookbook_paths,
+        :data_bags_path,
+        :encrypted_data_bag_secret_path,
+        :environments_path,
+        :execute_command,
+        :install_command,
+        :json,
+        :prevent_sudo,
+        :remote_cookbook_paths,
+        :roles_path,
+        :run_list,
+        :skip_install,
+        :staging_directory
+      ]
+    end
+  end
+end

--- a/spec/lib/evaluator_spec.rb
+++ b/spec/lib/evaluator_spec.rb
@@ -251,7 +251,7 @@ describe Packerman::Evaluator do
       end
     end
 
-    describe "Builder" do
+    describe "Provisioners" do
       context "shell" do
         let(:template) do
           <<-EOS.undent
@@ -281,6 +281,38 @@ describe Packerman::Evaluator do
                 type: "shell",
                 script: "echo $SHELL",
                 binary: true
+              }
+            ]
+          }
+        end
+
+        it_behaves_like :evaluated
+      end
+
+      context "chef-solo" do
+        let(:template) do
+          <<-EOS.undent
+          Provisioners type: "chef-solo" do
+            chef_attributes = { mysql: { version: "5.7", root_password: "plaintext" } }
+
+            cookbook_paths ["cookbooks", "vendor"]
+            json chef_attributes
+            run_list [
+              "role[web]",
+              "recipe[mysql]"
+            ]
+          end
+          EOS
+        end
+
+        let(:hash) do
+          {
+            provisioners: [
+              {
+                type: "chef-solo",
+                cookbook_paths: ["cookbooks", "vendor"],
+                json: { mysql: { version: "5.7", root_password: "plaintext" } },
+                run_list: ["role[web]", "recipe[mysql]"]
               }
             ]
           }


### PR DESCRIPTION
DSL implements for [chef-solo](https://github.com/mitchellh/packer/blob/135a607fb47e0b2ab4a48c152d583efcd8bde974/website/source/docs/provisioners/chef-solo.html.markdown)

``` ruby
Provisioners type: "chef-solo" do
  chef_attributes = { mysql: { version: "5.7", root_password: "plaintext" } }

  cookbook_paths ["cookbooks", "vendor"]
  json chef_attributes
  run_list [
    "role[web]",
    "recipe[mysql]"
  ]
end
```
